### PR TITLE
Manually adding fix to remove classpath warning

### DIFF
--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -194,7 +194,8 @@
                    (println " Building" (:name project) (:version project) (dump-profiles args))
                    (println "------------------------------------------------------------------------"))
                  (if-let [cmd (get-in project [:modules :subprocess] subprocess)]
-                   (binding [eval/*dir* (:root project)]
+                   (binding [eval/*dir* (:root project)
+                             eval/*env* (with-meta (dissoc (into {} (System/getenv)) "CLASSPATH") {:replace true})]
                      (let [exit-code (apply eval/sh (cons cmd args))]
                        (when (pos? exit-code)
                          (throw (ex-info "Subprocess failed" {:exit-code exit-code})))))


### PR DESCRIPTION
I like your changes to handle threading, however I wanted to know if you were also interested in pulling in a change to remove warnings about CLASSPATH being set: 

https://github.com/jcrossley3/lein-modules/pull/47/files

Also, there are 4 tests which are failing, but I don't think I understand what is going on to fix them myself. I would have created tickets for them as master has the problem.